### PR TITLE
Add flake8 to pre commit

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+ignore = E203, E266, E501, W503, F403, F401
+max-line-length = 79
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,11 @@
 repos:
-  - repo: https://github.com/psf/black
+-   repo: https://github.com/ambv/black
     rev: stable
     hooks:
-      - id: black
-        language_version: python3.7
+    - id: black
+      language_version: python3.7
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+    - id: flake8
+

--- a/docs/source/development/contributing.rst
+++ b/docs/source/development/contributing.rst
@@ -32,6 +32,26 @@ Now implement your modifications.
 The source code of the library is contained in the subdirectory ``treeopt``.
 Any new feature should be thoroughly tested, so please add unit tests in the ``tests`` subdirectory.
 
+Autoformat your code
+--------------------
+
+Your code stype should conform to the PEP. We use flake8 to check the code at every commit and decline 
+contributions that are not conform to the standard. Using a combination of the tools ``pre-commit``, 
+``black`` and ``flake8`` you can automatically re-format and check your code with every commit. To 
+activate this optional feature, install pre-commit
+
+.. code-block:: bash
+
+   pip install pre-commit
+   
+and install the pre-configured commit-hook for this repository. In the root directory of this repo, type
+
+.. code-block:: bash
+
+   pre-commit install
+   
+That's all there is to it!
+
 Commit your changes
 -------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.black]
+line-length = 79
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''
+


### PR DESCRIPTION
Previously, only the `black` code formatter was added as a pre-commit hook. This adds the `flake8` checker as well, since it is used to check the style in our CI workflow.